### PR TITLE
Merge IdleState attributes into IdleDetector

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -23,8 +23,7 @@ async function main() {
     // There is a minimum limit here of 60 seconds.
     let idleDetector = new IdleDetector({threshold: 60000});
     idleDetector.addEventListener('change', e => {
-      let {user, screen} = idleDetector.state;
-      console.log(`[${new Date().toLocaleString()}] idle change: ${user}, ${screen}`);
+      console.log(`[${new Date().toLocaleString()}] idle change: ${idleDetector.userState}, ${idleDetector.screenState}`);
     });
     await idleDetector.start();
   } catch (e) {

--- a/README.md
+++ b/README.md
@@ -68,18 +68,11 @@ enum ScreenIdleState {
 
 [
   SecureContext,
-  Exposed=(Window,DedicatedWorker),
-] interface IdleState {
-  readonly attribute UserIdleState user;
-  readonly attribute ScreenIdleState screen;
-};
-
-[
-  SecureContext,
   Exposed=(Window,DedicatedWorker)
 ] interface IdleDetector : EventTarget {
   constructor(optional IdleOptions options = {});
-  readonly attribute IdleState state;
+  readonly attribute UserIdleState userState;
+  readonly attribute ScreenIdleState screenState;
   attribute EventHandler onchange;
   Promise<void> start();
   void stop();
@@ -103,7 +96,7 @@ async function main() {
   try {
     const idleDetector = new IdleDetector({ threshold: 60000 });
     idleDetector.addEventListener('change', () => {
-      console.log(`idle change: ${idleDetector.state.user}, ${idleDetector.state.screen}`);
+      console.log(`idle change: ${idleDetector.userState}, ${idleDetector.screenState}`);
     });
     await idleDetector.start();
   } catch (e) {

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ enum ScreenIdleState {
   Exposed=(Window,DedicatedWorker)
 ] interface IdleDetector : EventTarget {
   constructor(optional IdleOptions options = {});
-  readonly attribute UserIdleState userState;
-  readonly attribute ScreenIdleState screenState;
+  readonly attribute UserIdleState? userState;
+  readonly attribute ScreenIdleState? screenState;
   attribute EventHandler onchange;
   Promise<void> start();
   void stop();

--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ dictionary IdleOptions {
 };
 
 enum UserIdleState {
+    "unknown",
     "active",
     "idle"
 };
 
 enum ScreenIdleState {
+    "unknown",
     "locked",
     "unlocked"
 };

--- a/README.md
+++ b/README.md
@@ -57,13 +57,11 @@ dictionary IdleOptions {
 };
 
 enum UserIdleState {
-    "unknown",
     "active",
     "idle"
 };
 
 enum ScreenIdleState {
-    "unknown",
     "locked",
     "unlocked"
 };


### PR DESCRIPTION
The `IdleState` interface seems unnecessary. These attributes can be added directly to the `IdleDetector` interface.

Fixes #18.