### PR TITLE
Add an AbortSignal to IdleOptions

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -20,13 +20,13 @@ async function main() {
   log("IdleDetector is available! Go idle!");
   
   try {
-    // There is a minimum limit here of 60 seconds.
-    let idleDetector = new IdleDetector({threshold: 60000});
+    let idleDetector = new IdleDetector();
     idleDetector.addEventListener('change', e => {
       let {user, screen} = idleDetector.state;
       console.log(`[${new Date().toLocaleString()}] idle change: ${user}, ${screen}`);
     });
-    await idleDetector.start();
+    // There is a minimum limit here of 60 seconds.
+    await idleDetector.start({threshold: 60000});
   } catch (e) {
     // deal with initialization errors.
     // permission denied, running outside of top-level frame, etc

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The API design is largely inspired by the [Sensors API](https://w3c.github.io/se
 ```js
 dictionary IdleOptions {
   [EnforceRange] unsigned long threshold = 60000; /* milliseconds */
+  AbortSignal? signal;
 };
 
 enum UserIdleState {
@@ -78,11 +79,10 @@ enum ScreenIdleState {
   SecureContext,
   Exposed=(Window,DedicatedWorker)
 ] interface IdleDetector : EventTarget {
-  constructor(optional IdleOptions options = {});
+  constructor();
   readonly attribute IdleState state;
   attribute EventHandler onchange;
-  Promise<void> start();
-  void stop();
+  Promise<void> start(optional IdleOptions options = {});
 };
 ```
 
@@ -101,11 +101,11 @@ async function main() {
   console.log("IdleDetector is available! Go idle!");
   
   try {
-    const idleDetector = new IdleDetector({ threshold: 60000 });
+    const idleDetector = new IdleDetector();
     idleDetector.addEventListener('change', () => {
       console.log(`idle change: ${idleDetector.state.user}, ${idleDetector.state.screen}`);
     });
-    await idleDetector.start();
+    await idleDetector.start({ threshold: 60000 });
   } catch (e) {
     // deal with initialization errors.
     // permission denied, running outside of top-level frame, etc

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ The API design is largely inspired by the [Sensors API](https://w3c.github.io/se
 
 ```js
 dictionary IdleOptions {
-  [EnforceRange] unsigned long threshold = 60000; /* milliseconds */
-  AbortSignal? signal;
+  [EnforceRange] unsigned long threshold;
+  AbortSignal signal;
 };
 
 enum UserIdleState {


### PR DESCRIPTION
An `AbortSignal` allows the `IdleDetector` and any other operations to be stopped with a single call to `AbortController.abort()`. So that a single detector can be restarted the options have been moved from the constructor to the `start()` method.

Fixes #19.