### PR TITLE
fix: Remove "for" on DIV

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -280,7 +280,7 @@ The <dfn method for=IdleDetector>requestPermission()</dfn> method steps are:
 
 ### {{IdleDetector/start()}} method ### {#api-idledetector-start}
 
-<div algorithm for="IdleDetector">
+<div algorithm>
 
 The <dfn method for=IdleDetector>start(|options|)</dfn> method steps are:
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nschonni/idle-detection/pull/38.html" title="Last updated on Feb 7, 2021, 12:27 AM UTC (f2c7f9f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/idle-detection/38/fd36c95...nschonni:f2c7f9f.html" title="Last updated on Feb 7, 2021, 12:27 AM UTC (f2c7f9f)">Diff</a>