### PR TITLE
Fix Bikeshed autolink shortcut syntax

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -309,7 +309,7 @@ The <dfn method for=IdleDetector>start(|options|)</dfn> method steps are:
       basics.tentative.https.window.js
     </wpt>
 1.  If |options|["{{signal}}"] is present, then perform the following sub-steps:
-    1.  If |options|["{{signal}"}'s [=AbortSignal/aborted flag=] is set, then
+    1.  If |options|["{{signal}}"]'s [=AbortSignal/aborted flag=] is set, then
         [=reject=] |result| with an "{{AbortError}}" {{DOMException}} and return
         |result|.
     1.  [=AbortSignal/add|Add the following abort steps=] to


### PR DESCRIPTION
(A drive-by fix.)

@reillyeon


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/anssiko/idle-detection/pull/39.html" title="Last updated on Apr 12, 2021, 4:47 PM UTC (ce491be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/idle-detection/39/4c169ee...anssiko:ce491be.html" title="Last updated on Apr 12, 2021, 4:47 PM UTC (ce491be)">Diff</a>