### PR TITLE
Update with DOM's abort reason

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -304,13 +304,13 @@ The <dfn method for=IdleDetector>start(|options|)</dfn> method steps are:
     </wpt>
 1.  Let |result| be [=a new promise=].
 1.  If |options|["{{signal}}"] is present, then perform the following sub-steps:
-    1.  If |options|["{{signal}}"]'s [=AbortSignal/aborted flag=] is set, then
-        [=reject=] |result| with an "{{AbortError}}" {{DOMException}} and return
-        |result|.
+    1.  If |options|["{{signal}}"] is [=AbortSignal/aborted=], then
+        [=reject=] |result| with |options|["{{signal}}"]'s [=AbortSignal/abort reason=]
+        and return |result|.
     1.  [=AbortSignal/add|Add the following abort steps=] to
         |options|["{{signal}}"]:
         1. Set |this|.{{IdleDetector/[[state]]}} to `"stopped"`.
-        1. [=Reject=] |result| with an "{{AbortError}}" {{DOMException}}.
+        1. [=Reject=] |result| with |options|["{{signal}}"]'s [=AbortSignal/abort reason=].
 
     <wpt>
       interceptor.https.html


### PR DESCRIPTION
https://github.com/whatwg/dom/pull/1027 removed the "aborted flag" from DOM's AbortSignal.
This change updates the Idle Detection spec with the [aborted](https://dom.spec.whatwg.org/#dom-abortsignal-aborted) predicate and rejecting promises with the signal's [abort reason](https://dom.spec.whatwg.org/#abortsignal-abort-reason), instead of with a new "AbortError" DOMException.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/idle-detection/pull/48.html" title="Last updated on Mar 15, 2022, 7:14 AM UTC (db13dc6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/idle-detection/48/a625789...nidhijaju:db13dc6.html" title="Last updated on Mar 15, 2022, 7:14 AM UTC (db13dc6)">Diff</a>