### PR TITLE
Remove now-incorrect backtick escaping

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -375,7 +375,7 @@ The {{IdleDetector}} can now be created and started. An listener for the
 try {
   const idleDetector = new IdleDetector();
   idleDetector.addEventListener('change', () => {
-    console.log(\`Idle change: ${idleDetector.userState}, ${idleDetector.screenState}.\`);
+    console.log(`Idle change: ${idleDetector.userState}, ${idleDetector.screenState}.`);
   });
   await idleDetector.start(options);
   console.log('IdleDetector is active.');


### PR DESCRIPTION
Bikeshed's markdown code parser now (as of version 3.14.0) properly handles markdown code blocks and won't accidentally parse backticks inside of them. As a result your workaround now looks broken. ^_^


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tabatkins/idle-detection/pull/51.html" title="Last updated on Jul 11, 2023, 9:00 PM UTC (88e8141)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/idle-detection/51/6035b7d...tabatkins:88e8141.html" title="Last updated on Jul 11, 2023, 9:00 PM UTC (88e8141)">Diff</a>