### PR TITLE
General specification maintenance 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -270,7 +270,9 @@ The <dfn method for=IdleDetector>requestPermission()</dfn> method steps are:
 1.  [=In parallel=]:
     1.  Let |permissionState| be the result of [=requesting permission to use=]
         <a permission>"idle-detection"</a>.
-    1.  [=Resolve=] |result| with |permissionState|.
+    1.  [=Queue a global task=] on the [=relevant global object=] of [=this=]
+        using the [=idle detection task source=] to [=resolve=] |result| with
+        |permissionState|.
 1. Return |result|.
 
 </div>
@@ -318,16 +320,17 @@ The <dfn method for=IdleDetector>start(|options|)</dfn> method steps are:
 1. [=In parallel=]:
     1.  Let |permissionState| be the [=permission state=] of `"idle-detection"`.
         <wpt>idle-permission.tentative.https.window.js</wpt>
-    1.  If |permissionState| is `"denied"`, [=queue a task=] on the
-        [=idle detection task source=] to perform the following steps:
-          1.  Set |this|.{{IdleDetector/[[state]]}} to `"stopped"`.
-          1.  [=Reject=] |result| with a "{{NotAllowedError}}" {{DOMException}}.
-    1.  Otherwise, [=queue a task=] on the [=idle detection task source=] to perform the
-        following steps, but [=abort when=] |this|.{{IdleDetector/[[state]]}}
-        becomes `"stopped"`.
-        1.  Set |this|.{{IdleDetector/[[state]]}} to `"started"`.
-        1.  Set |this|.{{IdleDetector/[[threshold]]}} to |options|["{{threshold}}"].
-        1.  [=Resolve=] |result|.
+    1.  [=Queue a global task=] on the [=relevant global object=] of [=this=]
+        using the [=idle detection task source=] to perform the following steps:
+        1.  If |permissionState| is `"denied"`,
+            1.  Set |this|.{{IdleDetector/[[state]]}} to `"stopped"`.
+            1.  [=Reject=] |result| with a "{{NotAllowedError}}" {{DOMException}}.
+        1.  Otherwise,
+            1.  If |this|.{{IdleDetector/[[state]]}} is `"stopped"`, abort these
+                steps.
+            1.  Set |this|.{{IdleDetector/[[state]]}} to `"started"`.
+            1.  Set |this|.{{IdleDetector/[[threshold]]}} to |options|["{{threshold}}"].
+            1.  [=Resolve=] |result|.
 1.  Return |result|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -345,6 +345,9 @@ The <dfn method for=IdleDetector>start(|options|)</dfn> method steps are:
             1.  [=Resolve=] |result|.
 1.  Return |result|.
 
+Note: The steps above are performed [=in parallel=] to enable implementations
+      to check the permission state asynchronously.
+
 </div>
 
 <div class="example">

--- a/index.bs
+++ b/index.bs
@@ -263,6 +263,12 @@ attribute</a> for the {{change}} event type.
 <div algorithm>
 The <dfn method for=IdleDetector>requestPermission()</dfn> method steps are:
 
+1.  If [=this=]'s [=relevant global object=]'s [=associated Document=] is not
+    [=fully active=], return [=a promise rejected with=] a
+    "{{InvalidStateError}}" {{DOMException}}.
+    <wpt>
+      idle-detection-detached-frame.https.html
+    </wpt>
 1.  If the [=relevant global object=] of [=this=] does not have [=transient
     activation=], return [=a promise rejected with=] a "{{NotAllowedError}}"
     {{DOMException}}.
@@ -283,9 +289,15 @@ The <dfn method for=IdleDetector>requestPermission()</dfn> method steps are:
 
 The <dfn method for=IdleDetector>start(|options|)</dfn> method steps are:
 
-1.  If the [=relevant global object=]'s [=associated Document=] is not [=allowed
-    to use=] <a permission>"idle-detection"</a>, return [=a promise rejected with=] a
-    "{{NotAllowedError}}" {{DOMException}}.
+1.  Let |document| be [=this=]'s [=relevant global object=]'s [=associated
+    Document=].
+1.  If |document| is not [=fully active=], return [=a promise rejected with=] a
+    "{{InvalidStateError}}" {{DOMException}}.
+    <wpt>
+      idle-detection-detached-frame.https.html
+    </wpt>
+1.  If |document| is not [=allowed to use=] <a permission>"idle-detection"</a>,
+    return [=a promise rejected with=] a "{{NotAllowedError}}" {{DOMException}}.
     <wpt>
       idle-detection-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html
       idle-detection-allowed-by-permissions-policy-attribute.https.sub.html

--- a/index.bs
+++ b/index.bs
@@ -287,11 +287,11 @@ The <dfn method for=IdleDetector>start(|options|)</dfn> method steps are:
     to use=] <a permission>"idle-detection"</a>, return [=a promise rejected with=] a
     "{{NotAllowedError}}" {{DOMException}}.
     <wpt>
-      idle-detection-allowed-by-feature-policy-attribute-redirect-on-load.https.sub.html
-      idle-detection-allowed-by-feature-policy-attribute.https.sub.html
-      idle-detection-allowed-by-feature-policy.https.sub.html
-      idle-detection-default-feature-policy.https.sub.html
-      idle-detection-disabled-by-feature-policy.https.sub.html
+      idle-detection-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html
+      idle-detection-allowed-by-permissions-policy-attribute.https.sub.html
+      idle-detection-allowed-by-permissions-policy.https.sub.html
+      idle-detection-default-permissions-policy.https.sub.html
+      idle-detection-disabled-by-permissions-policy.https.sub.html
     </wpt>
 1.  If |this|.{{IdleDetector/[[state]]}} is not `"stopped"`,
     return [=a promise rejected with=] an "{{InvalidStateError}}" {{DOMException}}.

--- a/index.bs
+++ b/index.bs
@@ -457,6 +457,7 @@ conditions:
 
 <wpt>
   interceptor.https.html
+  page-visibility.https.html
 </wpt>
 
 # Security and privacy considerations # {#security-and-privacy}
@@ -468,7 +469,7 @@ conditions:
 This interface exposes the state of global system properties and so care must be
 taken to prevent them from being used as cross-origin communication or
 identification channels. Similar concerns are present in specifications such as
-[[DEVICE-ORIENTATION]] and [[GEOLOCATION-API]], which mitigate them by requiring
+[[DEVICE-ORIENTATION]] and [[GEOLOCATION]], which mitigate them by requiring
 a visible or focused context. This prevents multiple origins from observing the
 global state at the same time. These mitigations are unfortunately inappropriate
 here because the intent of this specification is precisely to allow a limited


### PR DESCRIPTION
This PR adds proper queuing to for tasks started while in-parallel, including a missing case from inside the `requestPermission()` steps.

A number of additional Bikeshed warnings are also resolved, including fixing references to Web Platform Tests and the renamed "Geolocation" specification. To add references to all existing Web Platform Tests, "fully active" checks needed to be added to the `start()` and `requestPermission()` methods. These checks are already implemented.  

Fixed #54.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/idle-detection/pull/55.html" title="Last updated on Sep 10, 2024, 6:29 PM UTC (cfddd35)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/idle-detection/55/3537859...cfddd35.html" title="Last updated on Sep 10, 2024, 6:29 PM UTC (cfddd35)">Diff</a>